### PR TITLE
fix: pin eslint to 9.x and run lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@content-collections/core": "^0.15.0",
                 "@content-collections/mdx": "^0.2.2",
                 "@content-collections/next": "^0.2.9",
-                "eslint": "^10.0.0",
+                "eslint": "^9.39.5",
                 "eslint-config-next": "^16.1.0",
                 "eslint-config-prettier": "^10.1.8",
                 "prettier": "^3.7.4",
@@ -960,68 +960,118 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.23.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^3.0.5",
+                "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
-                "minimatch": "^10.2.4"
+                "minimatch": "^3.1.5"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
-            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^1.2.1"
+                "@eslint/core": "^0.17.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.3.0",
+                "minimatch": "^3.1.5",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^1.2.1",
+                "@eslint/core": "^0.17.0",
                 "levn": "^0.4.1"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@fal-works/esbuild-plugin-global-externals": {
@@ -1194,9 +1244,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1212,9 +1259,6 @@
             "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1232,9 +1276,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1250,9 +1291,6 @@
             "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1270,9 +1308,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1288,9 +1323,6 @@
             "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1308,9 +1340,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1327,9 +1356,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1345,9 +1371,6 @@
             "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1371,9 +1394,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1395,9 +1415,6 @@
             "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1421,9 +1438,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1445,9 +1459,6 @@
             "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1471,9 +1482,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1496,9 +1504,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1520,9 +1525,6 @@
             "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1813,9 +1815,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1831,9 +1830,6 @@
             "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1851,9 +1847,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1869,9 +1862,6 @@
             "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2107,9 +2097,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2125,9 +2112,6 @@
             "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2145,9 +2129,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2163,9 +2144,6 @@
             "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2342,13 +2320,6 @@
             "dependencies": {
                 "@types/ms": "*"
             }
-        },
-        "node_modules/@types/esrecurse": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -3198,6 +3169,29 @@
             "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
             "license": "MIT"
         },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
         "node_modules/aria-query": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -3497,26 +3491,14 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/brace-expansion/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/braces": {
@@ -3631,6 +3613,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/camelcase": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -3673,6 +3665,23 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/character-entities": {
@@ -3751,6 +3760,26 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
@@ -4304,33 +4333,33 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "dev": true,
             "license": "MIT",
-            "workspaces": [
-                "packages/*"
-            ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
-                "@eslint-community/regexpp": "^4.12.2",
-                "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.7.0",
-                "@eslint/core": "^1.2.1",
-                "@eslint/plugin-kit": "^0.7.2",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
+                "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
                 "ajv": "^6.14.0",
+                "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^9.1.2",
-                "eslint-visitor-keys": "^5.0.1",
-                "espree": "^11.2.0",
-                "esquery": "^1.7.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^8.0.0",
@@ -4340,7 +4369,8 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "minimatch": "^10.2.5",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -4348,7 +4378,7 @@
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
@@ -4387,17 +4417,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/eslint-config-next/node_modules/brace-expansion": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/eslint-config-next/node_modules/debug": {
@@ -4560,19 +4579,6 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
-        "node_modules/eslint-config-next/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/eslint-config-next/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4688,19 +4694,17 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@types/esrecurse": "^4.3.1",
-                "@types/estree": "^1.0.8",
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -4719,13 +4723,13 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -4745,31 +4749,31 @@
             }
         },
         "node_modules/espree": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.16.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^5.0.1"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -5375,6 +5379,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -5568,6 +5582,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/imurmurhash": {
@@ -6131,6 +6162,29 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
+        "node_modules/js-yaml": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6509,6 +6563,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/longest-streak": {
             "version": "3.1.0",
@@ -7477,19 +7538,16 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "*"
             }
         },
         "node_modules/minimist": {
@@ -7853,6 +7911,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/parse-entities": {
@@ -8369,6 +8440,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/resolve-pkg-maps": {
@@ -8929,6 +9010,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/style-to-js": {
             "version": "1.1.21",
             "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -8970,6 +9064,19 @@
                 "babel-plugin-macros": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@content-collections/core": "^0.15.0",
         "@content-collections/mdx": "^0.2.2",
         "@content-collections/next": "^0.2.9",
-        "eslint": "^10.0.0",
+        "eslint": "^9.39.5",
         "eslint-config-next": "^16.1.0",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.7.4",

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", "group:allNonMajor"],
-    "timezone": "Asia/Tokyo",
-    "packageRules": [
-        {
-            "description": "eslint-plugin-react (pulled in by eslint-config-next) does not support ESLint 10 yet; it still calls context.getFilename(), removed in v10. Keep major eslint updates listed on the Dependency Dashboard for manual approval instead of blocking them, so 10.x stays visible and can be retried by ticking its checkbox once upstream catches up. Minor and patch updates on 9.x keep flowing automatically.",
-            "matchPackageNames": ["eslint"],
-            "matchUpdateTypes": ["major"],
-            "dependencyDashboardApproval": true
-        }
-    ]
+    "timezone": "Asia/Tokyo"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", "group:allNonMajor"],
-    "timezone": "Asia/Tokyo"
+    "timezone": "Asia/Tokyo",
+    "packageRules": [
+        {
+            "description": "eslint-plugin-react (pulled in by eslint-config-next) does not support ESLint 10 yet; it still calls context.getFilename(), removed in v10. Hold eslint on 9.x until upstream ships support.",
+            "matchPackageNames": ["eslint"],
+            "allowedVersions": "<10"
+        }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,10 @@
     "timezone": "Asia/Tokyo",
     "packageRules": [
         {
-            "description": "eslint-plugin-react (pulled in by eslint-config-next) does not support ESLint 10 yet; it still calls context.getFilename(), removed in v10. Hold eslint on 9.x until upstream ships support.",
+            "description": "eslint-plugin-react (pulled in by eslint-config-next) does not support ESLint 10 yet; it still calls context.getFilename(), removed in v10. Keep major eslint updates listed on the Dependency Dashboard for manual approval instead of blocking them, so 10.x stays visible and can be retried by ticking its checkbox once upstream catches up. Minor and patch updates on 9.x keep flowing automatically.",
             "matchPackageNames": ["eslint"],
-            "allowedVersions": "<10"
+            "matchUpdateTypes": ["major"],
+            "dependencyDashboardApproval": true
         }
     ]
 }


### PR DESCRIPTION
## 背景

`npm run lint` が実行するたびにクラッシュしていました（main でも再現する既存の問題です）。

```
Oops! Something went wrong! :(

ESLint: 10.8.1

TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
    at resolveBasedir (node_modules/eslint-config-next/node_modules/eslint-plugin-react/lib/util/version.js:31:100)
```

## 原因

`eslint-config-next` が依存する `eslint-plugin-react` が、ESLint 10 で削除された `context.getFilename()` を今も呼んでいます。最新リリースの 7.37.5 でも peer は `eslint: ^3 || ... || ^9.7` で、**ESLint 10 に対応した公開バージョンは存在しません**（npm の `next` タグは 7.8.0-rc.0 で、バージョン番号どおり古い prerelease のため修正版ではありません）。

`eslint-config-next` 側は peer を `eslint: >=9.0.0` と宣言しており ESLint 10 を許容するように見えますが、内部でこのプラグインを読み込むため実際には動きません。上流に修正が入るまで回避策がなく、ESLint を 9 系に戻すのが唯一の実効的な解です。

## 変更内容

- `package.json`: `eslint` を `^10.0.0` → `^9.39.5` に固定
- `.github/workflows/ci.yml`: **lint を CI に追加**（新規）

`renovate.json` は変更していません（途中で eslint の major を抑止するルールを入れましたが、下記の理由で revert しました）。

### なぜ Renovate 側で抑止しないのか

そもそも壊れた eslint 10 が main に入ったのは、**CI が Vercel のビルドだけで lint を実行していなかった**からです。`next build` は eslint を一切呼ばないため、lint が全く動かない状態でも緑のままマージされていました。根本原因はここなので、CI に lint を足すのが本筋の対処です。

Renovate 側で `allowedVersions` や `dependencyDashboardApproval` を使って eslint 10 を抑止する案も検討しましたが、いずれも**自分で管理し続けないと正しさが保てない**ルールです。`eslint-plugin-react` が対応した瞬間に気づく仕組みが無く、放置すると塩漬けになります。

CI に lint がある状態なら、抑止ルールは不要です:

- `eslint-plugin-react` が非対応の間は、eslint 10 の PR は **CI が赤くなる**ので誤ってマージされない
- 上流が対応した日には、**誰も何もしなくても同じ PR が自然に緑になる**

判定を人間の記憶ではなく CI に委ねられるので、この形にしました。

## 確認したこと

- `npm run lint` → クリーン通過（エラー0件。これまで lint が動いていなかったため隠れた既存違反を懸念しましたが、0 件でした）
- 生成物（`.content-collections` / `.next`）を消したクリーンな状態でも lint が通ることを確認（CI のクリーンチェックアウトで動く裏取り）
- `npm run build` → 従来どおり成功（14 ページ生成、型チェック通過）
- ESLint は 9.39.5 に統一され、`eslint-config-next` 配下の nested な重複コピーも解消
- `actions/checkout@v7` / `actions/setup-node@v7` は実在するタグであることを確認済み