### PR TITLE
chore(renovate): switch to config:best-practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", "group:allNonMajor"],
+    "extends": ["config:best-practices", "group:allNonMajor"],
     "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
`extends` の `config:recommended` を `config:best-practices` に変更します。

`config:best-practices` は `config:recommended` をそのまま含んだ上位互換で、差分は以下の6つです。いずれも Renovate 側がメンテするプリセットなので、こちらで内容を管理し続ける必要はありません。

| プリセット | 内容 | このリポジトリへの影響 |
|---|---|---|
| `:configMigration` | renovate.json が古いオプション名を使っていたら移行 PR を出す | 設定が古びて動かなくなるのを防げる |
| `helpers:pinGitHubActionDigests` | Actions をコミット SHA で固定 | 先日追加した `actions/checkout` / `actions/setup-node` が対象。タグは後から動かせるため |
| `security:minimumReleaseAgeNpm` | npm パッケージを3日寝かせてから更新提案 | 公開直後の不正なパッケージや unpublish で壊れるのを避ける |
| `abandonments:recommended` | 1年リリースの無いパッケージを放置扱いとして通知 | `@types/*` は対象外、lodash は6年など、例外はコミュニティ側で管理される |
| `:pinDevDependencies` | devDependencies を厳密なバージョンに固定 | 現在キャレット指定のものが固定に変わる |
| `docker:pinDigests` | Docker イメージのダイジェスト固定 | Docker を使っていないため影響なし |

## 確認したこと

- `renovate-config-validator` で検証し、`Config validated successfully`

---
_Generated by [Claude Code](https://claude.ai/code/session_014n1YRAhQUjEHMUNNS2sA4f)_